### PR TITLE
Bump to latest fastify and fix keygen and tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 node_js:
+  - "10"
   - "9"
   - "8"
   - "6"

--- a/example.js
+++ b/example.js
@@ -29,14 +29,18 @@ fastify.inject({
   payload: {
     some: 'data'
   }
-}, (response) => {
+}, (error, response) => {
+  if(error) throw error;
+
   fastify.inject({
     method: 'GET',
     url: '/',
     headers: {
       cookie: response.headers['set-cookie']
     }
-  }, (response) => {
+  }, (error, response) => {
+    if(error) throw error;
+
     assert.deepEqual(JSON.parse(response.payload), { some: 'data' })
   })
 })

--- a/example.js
+++ b/example.js
@@ -30,7 +30,7 @@ fastify.inject({
     some: 'data'
   }
 }, (error, response) => {
-  if(error) throw error;
+  if (error) throw error
 
   fastify.inject({
     method: 'GET',
@@ -39,7 +39,7 @@ fastify.inject({
       cookie: response.headers['set-cookie']
     }
   }, (error, response) => {
-    if(error) throw error;
+    if (error) throw error
 
     assert.deepEqual(JSON.parse(response.payload), { some: 'data' })
   })

--- a/index.js
+++ b/index.js
@@ -18,9 +18,9 @@ module.exports = fp(function (fastify, options, next) {
     key = Buffer.allocUnsafe(sodium.crypto_secretbox_KEYBYTES)
 
     sodium.crypto_pwhash(key, Buffer.from(options.secret), salt,
-                         sodium.crypto_pwhash_OPSLIMIT_MODERATE,
-                         sodium.crypto_pwhash_MEMLIMIT_MODERATE,
-                         sodium.crypto_pwhash_ALG_DEFAULT)
+      sodium.crypto_pwhash_OPSLIMIT_MODERATE,
+      sodium.crypto_pwhash_MEMLIMIT_MODERATE,
+      sodium.crypto_pwhash_ALG_DEFAULT)
   }
 
   if (options.key) {

--- a/package.json
+++ b/package.json
@@ -26,14 +26,15 @@
   },
   "homepage": "https://github.com/mcollina/fastify-secure-session#readme",
   "devDependencies": {
-    "fastify": "^0.35.3",
+    "fastify": "^1.4.0",
     "pre-commit": "^1.2.2",
-    "standard": "^10.0.3",
-    "tap": "^11.0.0"
+    "standard": "^11.0.1",
+    "tap": "^11.1.4"
   },
   "dependencies": {
-    "fastify-cookie": "^1.1.2",
-    "fastify-plugin": "^0.1.1",
-    "sodium-native": "^2.0.1"
+    "fastify-cookie": "^2.0.1",
+    "fastify-plugin": "^1.0.1",
+    "sodium-native": "^2.1.6",
+    "sodium-universal": "^2.0.0"
   }
 }

--- a/test/key-base64.js
+++ b/test/key-base64.js
@@ -17,7 +17,7 @@ fastify.post('/', (request, reply) => {
 })
 
 t.tearDown(fastify.close.bind(fastify))
-t.plan(3)
+t.plan(5)
 
 fastify.get('/', (request, reply) => {
   const data = request.session.get('data')
@@ -34,7 +34,8 @@ fastify.inject({
   payload: {
     some: 'data'
   }
-}, (response) => {
+}, (error, response) => {
+  t.error(error)
   t.equal(response.statusCode, 200)
   t.ok(response.headers['set-cookie'])
 
@@ -44,7 +45,8 @@ fastify.inject({
     headers: {
       cookie: response.headers['set-cookie']
     }
-  }, (response) => {
+  }, (error, response) => {
+    t.error(error)
     t.deepEqual(JSON.parse(response.payload), { some: 'data' })
   })
 })

--- a/test/key.js
+++ b/test/key.js
@@ -17,7 +17,7 @@ fastify.post('/', (request, reply) => {
 })
 
 t.tearDown(fastify.close.bind(fastify))
-t.plan(3)
+t.plan(5)
 
 fastify.get('/', (request, reply) => {
   const data = request.session.get('data')
@@ -34,7 +34,8 @@ fastify.inject({
   payload: {
     some: 'data'
   }
-}, (response) => {
+}, (error, response) => {
+  t.error(error)
   t.equal(response.statusCode, 200)
   t.ok(response.headers['set-cookie'])
 
@@ -44,7 +45,8 @@ fastify.inject({
     headers: {
       cookie: response.headers['set-cookie']
     }
-  }, (response) => {
+  }, (error, response) => {
+    t.error(error)
     t.deepEqual(JSON.parse(response.payload), { some: 'data' })
   })
 })

--- a/test/secret.js
+++ b/test/secret.js
@@ -13,7 +13,7 @@ fastify.post('/', (request, reply) => {
 })
 
 t.tearDown(fastify.close.bind(fastify))
-t.plan(3)
+t.plan(5)
 
 fastify.get('/', (request, reply) => {
   const data = request.session.get('data')
@@ -30,7 +30,8 @@ fastify.inject({
   payload: {
     some: 'data'
   }
-}, (response) => {
+}, (error, response) => {
+  t.error(error)
   t.equal(response.statusCode, 200)
   t.ok(response.headers['set-cookie'])
 
@@ -40,7 +41,8 @@ fastify.inject({
     headers: {
       cookie: response.headers['set-cookie']
     }
-  }, (response) => {
+  }, (error, response) => {
+    t.error(error)
     t.deepEqual(JSON.parse(response.payload), { some: 'data' })
   })
 })


### PR DESCRIPTION
This PR:
- Brings dependencies up to latest versions
- Fixes tests broken by dep changes
- Includes `sodium-universal` which was missing from `package.json` for the keygen
- Removes extra spaces as per `standard`
