### PR TITLE
Added .delete() method to remove cookie from browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ fastify.get('/', (request, reply) => {
   }
   reply.send(data)
 })
+
+fastify.post('/logout', (request, reply) => {
+  request.session.delete()
+  reply.send('logged out')
+})
 ```
 
 ## Using a secret

--- a/index.js
+++ b/index.js
@@ -111,6 +111,11 @@ module.exports = fp(function (fastify, options, next) {
         // nothing to do
         next()
         return
+      } else if (session.deleted) {
+        const tmpCookieOptions = Object.assign({}, cookieOptions, { expires: new Date(0), maxAge: 0 })
+        reply.setCookie(cookieName, '', tmpCookieOptions)
+        next()
+        return
       }
 
       const nonce = genNonce()
@@ -131,6 +136,7 @@ class Session {
   constructor (obj) {
     this[kObj] = obj
     this.changed = false
+    this.deleted = false
   }
 
   get (key) {
@@ -140,6 +146,11 @@ class Session {
   set (key, value) {
     this.changed = true
     this[kObj][key] = value
+  }
+
+  delete () {
+    this.changed = true
+    this.deleted = true
   }
 }
 

--- a/test/delete.js
+++ b/test/delete.js
@@ -75,9 +75,6 @@ fastify.inject({
       t.error(error)
       t.equal(response.statusCode, 200)
       t.ok(response.headers['set-cookie'])
-
-      console.log(response.headers['set-cookie'])
-
       t.equal(cookie.parse(response.headers['set-cookie']).Path, '/')
       t.equal(cookie.parse(response.headers['set-cookie']).Expires, 'Thu, 01 Jan 1970 00:00:00 GMT')
       t.equal(cookie.parse(response.headers['set-cookie'])['Max-Age'], '0')

--- a/test/delete.js
+++ b/test/delete.js
@@ -1,0 +1,86 @@
+'use strict'
+
+const t = require('tap')
+const fastify = require('fastify')({ logger: false })
+const sodium = require('sodium-native')
+const cookie = require('cookie')
+const key = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
+const expires = new Date(Date.now() + (86400 * 1000))
+const expiresUTC = expires.toUTCString()
+
+sodium.randombytes_buf(key)
+
+fastify.register(require('../'), {
+  key,
+  cookie: {
+    path: '/',
+    expires: expires,
+    maxAge: 86400
+  }
+})
+
+fastify.post('/', (request, reply) => {
+  request.session.set('some', request.body.some)
+  request.session.set('some2', request.body.some2)
+  reply.send('hello world')
+})
+
+fastify.post('/delete', (request, reply) => {
+  request.session.delete()
+  reply.send('hello world')
+})
+
+t.tearDown(fastify.close.bind(fastify))
+t.plan(14)
+
+fastify.get('/', (request, reply) => {
+  const some = request.session.get('some')
+  const some2 = request.session.get('some2')
+  if (!some || !some2) {
+    reply.code(404).send()
+    return
+  }
+  reply.send({ some: some, some2: some2 })
+})
+
+fastify.inject({
+  method: 'POST',
+  url: '/',
+  payload: {
+    some: 'someData',
+    some2: { a: 1, b: undefined, c: 3 }
+  }
+}, (error, response) => {
+  t.error(error)
+  t.equal(response.statusCode, 200)
+  t.ok(response.headers['set-cookie'])
+  t.equal(cookie.parse(response.headers['set-cookie']).Path, '/')
+  t.equal(cookie.parse(response.headers['set-cookie']).Expires, expiresUTC)
+  t.equal(cookie.parse(response.headers['set-cookie'])['Max-Age'], '86400')
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      cookie: response.headers['set-cookie']
+    }
+  }, (error, response) => {
+    t.error(error)
+    t.deepEqual(JSON.parse(response.payload), { some: 'someData', some2: { a: 1, c: 3 } })
+
+    fastify.inject({
+      method: 'POST',
+      url: '/delete'
+    }, (error, response) => {
+      t.error(error)
+      t.equal(response.statusCode, 200)
+      t.ok(response.headers['set-cookie'])
+
+      console.log(response.headers['set-cookie'])
+
+      t.equal(cookie.parse(response.headers['set-cookie']).Path, '/')
+      t.equal(cookie.parse(response.headers['set-cookie']).Expires, 'Thu, 01 Jan 1970 00:00:00 GMT')
+      t.equal(cookie.parse(response.headers['set-cookie'])['Max-Age'], '0')
+    })
+  })
+})


### PR DESCRIPTION
Refer to Issue #13 

This includes a test to verify both of my use cases:

1. remove key(s) inside of values that are objects by deleting the inner keys or setting them to undefined. This was already possible without the PR, but the test proves that.
2. instruct the browser to remove the cookie using both expires and max-age when using the added .delete() method

I didn't update the README, as I figured you would like to do that.