### PR TITLE
Add malformed cookie detection and test

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,13 @@ module.exports = fp(function (fastify, options, next) {
       const cyphertextB64 = split[0]
       const nonceB64 = split[1]
 
+      if (split.length <= 1) {
+        // the cookie is malformed
+        request.session = new Session({})
+        next()
+        return
+      }
+
       const cipher = Buffer.from(cyphertextB64, 'base64')
       const nonce = Buffer.from(nonceB64, 'base64')
 

--- a/test/malformed-cookie.js
+++ b/test/malformed-cookie.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const t = require('tap')
+const fastify = require('fastify')({ logger: false })
+const sodium = require('sodium-native')
+const key = Buffer.alloc(sodium.crypto_secretbox_KEYBYTES)
+
+sodium.randombytes_buf(key)
+
+fastify.register(require('../'), {
+  key
+})
+
+fastify.post('/', (request, reply) => {
+  request.session.set('data', request.body)
+  reply.send('hello world')
+})
+
+t.tearDown(fastify.close.bind(fastify))
+t.plan(5)
+
+fastify.get('/', (request, reply) => {
+  const data = request.session.get('data')
+  if (!data) {
+    reply.code(404).send()
+    return
+  }
+  reply.send(data)
+})
+
+fastify.inject({
+  method: 'POST',
+  url: '/',
+  payload: {
+    some: 'data'
+  }
+}, (error, response) => {
+  t.error(error)
+  t.equal(response.statusCode, 200)
+  t.ok(response.headers['set-cookie'])
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      cookie: 'session='
+    }
+  }, (error, response) => {
+    t.error(error)
+    t.equal(response.statusCode, 404)
+  })
+})


### PR DESCRIPTION
Malformed cookies currently cause an uncaught exception. This incorporates the solution from @sreekotay's [PR from last month](https://github.com/mcollina/fastify-secure-session/pull/19), and follows @mcollina's [idea for testing that solution](https://github.com/mcollina/fastify-secure-session/pull/19#issuecomment-480494807).