### PR TITLE
update sodium-native to 3.0.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 node_js:
+  - "13"
   - "12"
   - "10"
   - "8"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   "dependencies": {
     "fastify-cookie": "^3.0.0",
     "fastify-plugin": "^1.5.0",
-    "sodium-native": "^2.3.0"
+    "sodium-native": "^3.0.0"
   }
 }


### PR DESCRIPTION
sodium-native 3.0.0 has been updated to use n-api, so there shouldn't be any more issues with fastify-secure-session preventing newer versions of node.js from being used due to ABI changes / node-gyp compile errors.